### PR TITLE
Add MoE-ReFT project entry to Projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -85,6 +85,15 @@
                 <a href="https://github.com/run-llama/llama-hub/tree/main/llama_hub/earnings_call_transcript">earnings call transcripts</a>.
               </p>
             </article>
+            <article class="project-card">
+              <h3>MoE-ReFT</h3>
+              <p>
+                Explored parameter-efficient finetuning with ReFT (<a href="https://arxiv.org/abs/2404.03592">representation finetuning</a>)
+                by adding interventions before and after MoE layers in OLMoE-7B-A1B.
+                Base GSM8k test loss was 0.82, pre-MoE was 0.91, and post-MoE was 10.8.
+                <a href="https://github.com/Athe-kunal/MoE-ReFT">GitHub repo</a>.
+              </p>
+            </article>
             <article class="project-card project-card--media">
               <div>
                 <h3>Movie Reviews Question Answering Agent</h3>


### PR DESCRIPTION
### Motivation
- Add a concise project entry describing experiments with ReFT on OLMoE-7B-A1B and report GSM8k test loss comparisons.

### Description
- Inserted a new `<article class="project-card">` in `projects.html` titled “MoE-ReFT” that links to the ReFT paper and the repository and summarizes the reported GSM8k test losses (base 0.82, pre-MoE 0.91, post-MoE 10.8).

### Testing
- Served the static site with `python -m http.server 8000` and ran a Playwright script to capture a screenshot of `projects.html`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d986428dc8330af8445e6cad40b74)