### PR TITLE
Add DDP for LLMs playlist to Projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -51,6 +51,14 @@
                 <a href="https://github.com/Athe-kunal/Helion-Puzzles">Helion and Triton Puzzles</a> 
               </p>
             </article>
+            <article class="project-card">
+              <h3>Teaching Distributed Data Parallelism for LLMs</h3>
+              <p>
+                This playlist is about going from theory to practice for training large models.
+                Watch the
+                <a href="https://youtube.com/playlist?list=PLtYQQQmDwvJsAJ9Tc9iy5MEGpldvRip3V&amp;si=MTPmU8Cfr4euPe9s">playlist</a>.
+              </p>
+            </article>
              <article class="project-card">
               <h3>MoE-ReFT</h3>
               <p>


### PR DESCRIPTION
### Motivation
- Add a plain-language entry linking to a YouTube playlist that teaches distributed data parallelism for training large language models, described as going from theory to practice.

### Description
- Updated `projects.html` to insert a new project card titled "Teaching Distributed Data Parallelism for LLMs" containing the sentence "This playlist is about going from theory to practice for training large models." and the provided YouTube playlist hyperlink.

### Testing
- Verified the update by serving the site with `python3 -m http.server 8000 --bind 0.0.0.0` and capturing a full-page screenshot via a Playwright script using `page.goto('http://127.0.0.1:8000/projects.html', wait_until='networkidle')`, which produced `artifacts/projects-page-update.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1381831e88330bf98ac26608a2c0c)