### PR TITLE
Add 'Sequence Length Balancing in Rust' project card and small-image CSS

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -244,6 +244,12 @@ main {
   box-shadow: 0 15px 30px rgba(26, 28, 30, 0.12);
 }
 
+.project-card__image--small {
+  width: min(100%, 220px) !important;
+  display: block;
+  margin-inline: auto;
+}
+
 .project-card--media figcaption {
   margin-top: 0.65rem;
   color: var(--text-muted);

--- a/projects.html
+++ b/projects.html
@@ -79,6 +79,24 @@
             </article>
             <article class="project-card project-card--media">
               <div>
+                <h3>Sequence Length Balancing in Rust</h3>
+                <p>
+                  Built a Rust project for sequence length balancing with a scheduler backed by a ZMQ server
+                  using a ROUTER-DEALER architecture. See the
+                  <a href="https://github.com/Athe-kunal/seq-len-balance-rs">GitHub repo</a>.
+                </p>
+              </div>
+              <figure>
+                <img
+                  class="project-card__image--small"
+                  src="https://raw.githubusercontent.com/Athe-kunal/seq-len-balance-rs/main/benchmark/kk_benchmark.png"
+                  alt="Benchmark plot for sequence length balancing"
+                />
+                <figcaption>Sequence length balancing benchmark.</figcaption>
+              </figure>
+            </article>
+            <article class="project-card project-card--media">
+              <div>
                 <h3>SEC Filings Question Answering Agent</h3>
                 <p>
                   Built an end-to-end system that parses <code>10-Q</code> and <code>10-K</code> filings to answer investor


### PR DESCRIPTION
### Motivation

- Add a new project entry showcasing a Rust sequence length balancing implementation with an accompanying benchmark image and ensure the image is sized appropriately in the project cards.

### Description

- Add a new project `article` to `projects.html` titled "Sequence Length Balancing in Rust" with a description, GitHub link, benchmark image, and figcaption. 
- Introduce a new CSS utility class `project-card__image--small` in `assets/css/styles.css` to constrain images to `width: min(100%, 220px)` and center them using `display: block` and `margin-inline: auto`. 
- Apply the new `project-card__image--small` class to the inserted `<img>` so the benchmark plot renders at the intended small size.

### Testing

- No automated tests were run for this content and styling change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adfa42df3883309da50afb3206f002)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static content and styling-only changes; main risk is minor layout/regression from the new `!important` width override.
> 
> **Overview**
> Adds a new `projects.html` entry for **Sequence Length Balancing in Rust**, including a GitHub link and an externally hosted benchmark image with caption.
> 
> Introduces a CSS helper class `project-card__image--small` in `assets/css/styles.css` to render smaller, centered images within project media cards, and applies it to the new benchmark image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b58dd1846592e79f92788b88356f2776a6b108fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->